### PR TITLE
Add single-page website with four navigation sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Single Page Navigation Demo</title>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: "Helvetica Neue", Arial, sans-serif;
+      color: #222;
+      background: #f7f7f9;
+      line-height: 1.6;
+    }
+
+    header {
+      position: sticky;
+      top: 0;
+      background: #ffffffee;
+      backdrop-filter: blur(6px);
+      border-bottom: 1px solid #e2e8f0;
+      z-index: 1000;
+    }
+
+    nav {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 1rem 1.5rem;
+    }
+
+    nav .brand {
+      font-weight: 700;
+      font-size: 1.2rem;
+      letter-spacing: 0.05em;
+      color: #2563eb;
+    }
+
+    nav ul {
+      display: flex;
+      gap: 1.25rem;
+      padding: 0;
+      margin: 0;
+      list-style: none;
+    }
+
+    nav a {
+      text-decoration: none;
+      color: #1f2937;
+      font-weight: 500;
+      padding: 0.25rem 0;
+      position: relative;
+    }
+
+    nav a::after {
+      content: "";
+      position: absolute;
+      left: 0;
+      bottom: -0.35rem;
+      width: 100%;
+      height: 2px;
+      background: #2563eb;
+      transform: scaleX(0);
+      transform-origin: left;
+      transition: transform 0.2s ease-in-out;
+    }
+
+    nav a:hover::after,
+    nav a:focus::after,
+    nav a.active::after {
+      transform: scaleX(1);
+    }
+
+    section {
+      min-height: 75vh;
+      padding: 4rem 1.5rem;
+      display: flex;
+      align-items: center;
+    }
+
+    .section-content {
+      max-width: 720px;
+      margin: 0 auto;
+    }
+
+    h1, h2 {
+      margin-bottom: 1rem;
+    }
+
+    p {
+      margin-bottom: 1rem;
+    }
+
+    .cta-button {
+      display: inline-block;
+      margin-top: 1rem;
+      padding: 0.75rem 1.5rem;
+      background: #2563eb;
+      color: #fff;
+      border-radius: 999px;
+      text-decoration: none;
+      font-weight: 600;
+      box-shadow: 0 10px 20px rgba(37, 99, 235, 0.2);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .cta-button:hover,
+    .cta-button:focus {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
+    }
+
+    footer {
+      text-align: center;
+      padding: 2rem 1rem 3rem;
+      color: #6b7280;
+    }
+
+    @media (max-width: 640px) {
+      nav {
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      nav ul {
+        flex-wrap: wrap;
+        justify-content: center;
+      }
+
+      section {
+        padding: 3rem 1.25rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <nav>
+      <div class="brand">IDIA</div>
+      <ul>
+        <li><a class="active" href="#home">Home</a></li>
+        <li><a href="#about">About</a></li>
+        <li><a href="#services">Services</a></li>
+        <li><a href="#contact">Contact</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main>
+    <section id="home">
+      <div class="section-content">
+        <h1>Welcome to IDIA</h1>
+        <p>
+          Discover a modern single-page layout with smooth navigation and engaging content. This
+          example highlights how a compact structure can deliver a complete story about your brand
+          without requiring visitors to jump between multiple pages.
+        </p>
+        <a class="cta-button" href="#contact">Start a Conversation</a>
+      </div>
+    </section>
+
+    <section id="about">
+      <div class="section-content">
+        <h2>About</h2>
+        <p>
+          We craft digital experiences designed around clarity and purpose. Our approach blends clean
+          design with thoughtful storytelling so visitors understand who you are and why your work
+          matters.
+        </p>
+        <p>
+          Each section on this page demonstrates how you can guide users through your narrative,
+          keeping your most important message front and center.
+        </p>
+      </div>
+    </section>
+
+    <section id="services">
+      <div class="section-content">
+        <h2>Services</h2>
+        <p>
+          From concept to launch, our team supports every step of your digital journey. Whether you
+          need a brand refresh, a new product microsite, or a polished marketing landing page, we
+          bring your ideas to life with responsive layouts and accessible interactions.
+        </p>
+        <p>
+          This single-page template shows how to organize offerings into digestible sections that are
+          easy to navigate on any device.
+        </p>
+      </div>
+    </section>
+
+    <section id="contact">
+      <div class="section-content">
+        <h2>Contact</h2>
+        <p>
+          Ready to collaborate? Reach out and let&apos;s design something remarkable together. Share your
+          project goals, timeline, and inspiration so we can craft a proposal tailored to your needs.
+        </p>
+        <p>
+          Email us at <a href="mailto:hello@example.com">hello@example.com</a> or call
+          <a href="tel:+1234567890">(123) 456-7890</a>.
+        </p>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    &copy; <span id="year"></span> IDIA Studio. All rights reserved.
+  </footer>
+
+  <script>
+    // Update the footer year automatically.
+    document.getElementById("year").textContent = new Date().getFullYear();
+
+    // Highlight the current navigation link based on scroll position.
+    const navLinks = document.querySelectorAll("nav a");
+    const sections = Array.from(navLinks).map(link => document.querySelector(link.getAttribute("href")));
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        const index = sections.indexOf(entry.target);
+        if (index !== -1) {
+          navLinks[index].classList.toggle("active", entry.isIntersecting);
+        }
+      });
+    }, {
+      threshold: 0.6
+    });
+
+    sections.forEach(section => {
+      if (section) {
+        observer.observe(section);
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a responsive single-page layout with Home, About, Services, and Contact sections
- implement sticky navigation highlighting the active section
- add simple call-to-action and contact details with auto-updating footer year

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6cd09948c8324b57e96de98bdf108