### PR TITLE
Set default font to Big Shoulders Stencil

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Single Page Navigation Demo</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Big+Shoulders+Stencil:opsz,wght@10..72,100..900&display=swap" rel="stylesheet">
   <style>
     * {
       box-sizing: border-box;
@@ -11,7 +14,7 @@
 
     body {
       margin: 0;
-      font-family: "Helvetica Neue", Arial, sans-serif;
+      font-family: "Big Shoulders Stencil", "Helvetica Neue", Arial, sans-serif;
       color: #222;
       background: #f7f7f9;
       line-height: 1.6;


### PR DESCRIPTION
## Summary
- load the Big Shoulders Stencil font from Google Fonts
- apply the new typeface as the default body font for the site

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6de6b2d9883249898733c11d48e23