### PR TITLE
Center navigation menu with separators and superscripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,8 @@
     nav {
       display: flex;
       align-items: center;
-      justify-content: space-between;
+      justify-content: center;
+      gap: 1rem;
       max-width: 960px;
       margin: 0 auto;
       padding: 1rem 1.5rem;
@@ -44,10 +45,17 @@
 
     nav ul {
       display: flex;
-      gap: 1.25rem;
+      gap: 0;
       padding: 0;
       margin: 0;
       list-style: none;
+      align-items: center;
+    }
+
+    nav ul li + li::before {
+      content: "\2192";
+      color: #9ca3af;
+      margin: 0 1rem;
     }
 
     nav a {
@@ -56,6 +64,11 @@
       font-weight: 500;
       padding: 0.25rem 0;
       position: relative;
+    }
+
+    sup {
+      font-size: 0.65em;
+      letter-spacing: 0.08em;
     }
 
     nav a::after {
@@ -145,8 +158,8 @@
       <div class="brand">IDIA</div>
       <ul>
         <li><a class="active" href="#image">(IMAGE)</a></li>
-        <li><a href="#ai-png">(AI-PNG)</a></li>
-        <li><a href="#ai-3d">(AI-3D)</a></li>
+        <li><a href="#ai-png">(AI-<sup>PNG</sup>)</a></li>
+        <li><a href="#ai-3d">(AI-<sup>3D</sup>)</a></li>
         <li><a href="#printed0">(PRINTED0)</a></li>
       </ul>
     </nav>
@@ -167,7 +180,7 @@
 
     <section id="ai-png">
       <div class="section-content">
-        <h2>AI-Powered PNG Exports</h2>
+        <h2>AI-Powered <sup>PNG</sup> Exports</h2>
         <p>
           Generate crisp, transparent-background assets ideal for branding, UI overlays, and rapid
           iteration. Intelligent edge detection and tone mapping ensure every export is production-ready.
@@ -181,7 +194,7 @@
 
     <section id="ai-3d">
       <div class="section-content">
-        <h2>AI-Driven 3D Models</h2>
+        <h2>AI-Driven <sup>3D</sup> Models</h2>
         <p>
           Harness procedural generation and machine learning to craft detailed 3D assets faster than
           ever. From product visualizations to cinematic environments, our AI toolchain accelerates


### PR DESCRIPTION
## Summary
- center the navigation brand and menu group within the header
- add arrow separators between menu items and style PNG/3D labels as superscripts in navigation and section headings

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d6df151190832483b9896073ab4b09