### PR TITLE
Adjust navigation styling and hero background

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,14 +34,13 @@
       align-items: center;
       justify-content: space-between;
       gap: 1rem;
-      max-width: 960px;
-      margin: 0 auto;
-      padding: 1rem 1.5rem;
+      padding: 1rem 2rem;
+      width: 100%;
     }
 
     nav .brand {
-      font-weight: 700;
-      font-size: 1.2rem;
+      font-weight: 400;
+      font-size: 3rem;
       letter-spacing: 0.05em;
       color: #2563eb;
     }
@@ -55,43 +54,38 @@
       align-items: center;
     }
 
+    nav ul li {
+      display: flex;
+      align-items: center;
+    }
+
     nav ul li + li::before {
       content: "\2192";
       color: #9ca3af;
       margin: 0 1rem;
+      font-size: 3rem;
+      display: inline-flex;
+      align-items: center;
+      line-height: 1;
     }
 
     nav a {
       text-decoration: none;
       color: #1f2937;
-      font-weight: 500;
+      font-weight: 400;
       font-size: 3rem;
       padding: 0.25rem 0;
-      position: relative;
+    }
+
+    nav a.active,
+    nav a:focus,
+    nav a:hover {
+      color: #2563eb;
     }
 
     sup {
       font-size: 0.65em;
       letter-spacing: 0.08em;
-    }
-
-    nav a::after {
-      content: "";
-      position: absolute;
-      left: 0;
-      bottom: -0.35rem;
-      width: 100%;
-      height: 2px;
-      background: #2563eb;
-      transform: scaleX(0);
-      transform-origin: left;
-      transition: transform 0.2s ease-in-out;
-    }
-
-    nav a:hover::after,
-    nav a:focus::after,
-    nav a.active::after {
-      transform: scaleX(1);
     }
 
     section {
@@ -102,8 +96,14 @@
     }
 
     .section-content {
-      max-width: 720px;
-      margin: 0 auto;
+      width: 100%;
+    }
+
+    #image {
+      background-image: url("./public/museum.jpg");
+      background-size: cover;
+      background-position: center;
+      color: #0f172a;
     }
 
     h1, h2 {


### PR DESCRIPTION
## Summary
- remove the hover underline treatment and soften navigation typography
- align navigation arrows with the menu items and match the brand sizing
- update the hero section to use the museum image while expanding layouts to full width

## Testing
- Manual verification

------
https://chatgpt.com/codex/tasks/task_e_68d6fd8299a08324884a59f17ab7d458